### PR TITLE
Add dark mode feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ SmartFill AI is an intelligent Chrome extension that automates filling out web f
 - **User Profile Management**: Easily save and edit your profile information (name, email, professional summary, etc.) directly within the extension popup.
 - **Robust Field Detection**: Uses XPath to reliably identify form fields, making it compatible with dynamic pages built with frameworks like React or Angular.
 - **Secure**: Your API key and profile data are stored locally on your machine using Chrome's storage API and are never shared externally.
+- **Dark Mode**: Toggle between light and dark themes in both the popup and settings pages.
 
 ## Quick Setup
 
@@ -51,6 +52,9 @@ To get started with SmartFill AI, follow these steps to load it as an unpacked e
     - Click the SmartFill AI icon.
     - Click the "Smart Fill Form" button.
     - The extension will scan the page, analyze the fields, and fill them in based on your profile.
+
+4.  **Switch Themes**:
+    - Use the moon icon in the popup or settings page to toggle dark mode.
 
 ## Technology Stack
 

--- a/options.html
+++ b/options.html
@@ -5,12 +5,22 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>SmartFill Settings</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    .dark .profile-input {
+      background-color: #1f2937;
+      border-color: #374151;
+      color: #f3f4f6;
+    }
+  </style>
 </head>
-<body class="bg-gray-50">
+<body class="bg-gray-50 dark:bg-gray-900 dark:text-gray-100">
   <div class="max-w-4xl mx-auto py-10 px-6">
     <div class="flex items-center justify-between pb-6 border-b">
-      <h1 class="text-3xl font-bold text-gray-800">SmartFill Settings</h1>
-      <div id="status" class="text-green-600 font-medium transition-opacity duration-300 opacity-0"></div>
+      <h1 class="text-3xl font-bold text-gray-800 dark:text-gray-100">SmartFill Settings</h1>
+      <div class="flex items-center gap-4">
+        <button id="theme-toggle" class="text-xl" title="Toggle theme">🌓</button>
+        <div id="status" class="text-green-600 font-medium transition-opacity duration-300 opacity-0"></div>
+      </div>
     </div>
 
     <p class="text-gray-600 mt-4">This is your central profile. The more detail you provide, the better the AI can fill out forms for you. All changes are saved automatically.</p>

--- a/options.js
+++ b/options.js
@@ -1,5 +1,14 @@
 document.addEventListener('DOMContentLoaded', () => {
   const statusDiv = document.getElementById('status');
+  const themeToggle = document.getElementById('theme-toggle');
+
+  function applyTheme(theme) {
+    if (theme === 'dark') {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  }
 
   // Define all profile input elements
   const inputs = {
@@ -27,7 +36,7 @@ document.addEventListener('DOMContentLoaded', () => {
   let saveTimeout;
 
   // Load the existing profile from storage and populate the form
-  chrome.storage.local.get('userProfile', (result) => {
+  chrome.storage.local.get(['userProfile', 'theme'], (result) => {
     if (result.userProfile) {
       userProfile = { ...defaultProfile, ...result.userProfile };
     }
@@ -35,6 +44,9 @@ document.addEventListener('DOMContentLoaded', () => {
       if (inputs[key]) {
         inputs[key].value = userProfile[key] || '';
       }
+    }
+    if (result.theme) {
+      applyTheme(result.theme);
     }
   });
 
@@ -64,4 +76,10 @@ document.addEventListener('DOMContentLoaded', () => {
       inputs[key].addEventListener('input', handleProfileChange);
     }
   }
+
+  themeToggle.addEventListener('click', () => {
+    const newTheme = document.documentElement.classList.contains('dark') ? 'light' : 'dark';
+    applyTheme(newTheme);
+    chrome.storage.local.set({ theme: newTheme });
+  });
 });

--- a/popup.html
+++ b/popup.html
@@ -14,10 +14,17 @@
       background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
       color: #333;
     }
+    body.dark {
+      background: linear-gradient(135deg, #2c2c54 0%, #4b367c 100%);
+      color: #e0e0e0;
+    }
     .container {
       background: white;
       margin: 0;
       min-height: 500px;
+    }
+    body.dark .container {
+      background: #1e1e1e;
     }
     .header {
       background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
@@ -26,6 +33,9 @@
       display: flex;
       justify-content: space-between;
       align-items: center;
+    }
+    body.dark .header {
+      background: linear-gradient(135deg, #343a40 0%, #212529 100%);
     }
     .title {
       font-size: 20px;
@@ -64,6 +74,11 @@
       border: 1px solid #b3d9ff;
       font-weight: 500;
     }
+    body.dark .profile-status {
+      background: #2b3035;
+      color: #d1d5db;
+      border-color: #3c4043;
+    }
     .autofill-btn {
       width: 100%;
       background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
@@ -77,6 +92,9 @@
       margin-bottom: 16px;
       transition: all 0.3s;
       box-shadow: 0 4px 15px rgba(102, 126, 234, 0.3);
+    }
+    body.dark .autofill-btn {
+      box-shadow: 0 4px 15px rgba(102, 126, 234, 0.4);
     }
     .autofill-btn:hover {
       transform: translateY(-2px);
@@ -94,6 +112,11 @@
       background: #f8f9fa;
       border-radius: 8px;
       border: 1px solid #e9ecef;
+    }
+    body.dark .status {
+      background: #2b3035;
+      border-color: #3c4043;
+      color: #ccc;
     }
     .form-section {
       margin-bottom: 24px;
@@ -128,6 +151,12 @@
       transition: all 0.2s;
       background: #f8f9fa;
     }
+    body.dark .form-group input,
+    body.dark .form-group textarea {
+      background: #343a40;
+      border-color: #495057;
+      color: #eee;
+    }
     .form-group input:focus, .form-group textarea:focus {
       outline: none;
       border-color: #667eea;
@@ -146,6 +175,9 @@
       transition: all 0.2s;
       box-shadow: 0 2px 10px rgba(40, 167, 69, 0.3);
     }
+    body.dark .btn {
+      box-shadow: 0 2px 10px rgba(40, 167, 69, 0.5);
+    }
     .btn:hover {
       transform: translateY(-1px);
       box-shadow: 0 4px 15px rgba(40, 167, 69, 0.4);
@@ -156,6 +188,9 @@
     }
     .btn-secondary:hover {
       box-shadow: 0 4px 15px rgba(108, 117, 125, 0.4);
+    }
+    body.dark .divider {
+      background: linear-gradient(90deg, transparent, #3c4043, transparent);
     }
     .divider {
       height: 1px;
@@ -178,7 +213,10 @@
           <span>🤖</span>
           <span>SmartFill AI</span>
         </div>
-        <button id="settings-toggle" class="settings-btn">⚙️</button>
+        <div>
+          <button id="theme-toggle" class="settings-btn" title="Toggle theme">🌓</button>
+          <button id="settings-toggle" class="settings-btn">⚙️</button>
+        </div>
       </div>
       
       <div class="content">

--- a/popup.js
+++ b/popup.js
@@ -9,6 +9,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const mainView = document.getElementById('main-view');
   const settingsView = document.getElementById('settings-view');
   const settingsToggle = document.getElementById('settings-toggle');
+  const themeToggle = document.getElementById('theme-toggle');
   const backBtn = document.getElementById('back-btn');
   const apiKeyInput = document.getElementById('api-key');
   const saveKeyBtn = document.getElementById('save-key-btn');
@@ -16,6 +17,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const statusDiv = document.getElementById('status');
   const profileStatusDiv = document.getElementById('profile-status');
   const expandProfileBtn = document.getElementById('expand-profile-btn');
+
+  function applyTheme(theme) {
+    document.body.classList.toggle('dark', theme === 'dark');
+  }
 
   // Profile input fields
   const nameInput = document.getElementById('name');
@@ -29,7 +34,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Load data from storage
   function loadData() {
-    chrome.storage.local.get(['userProfile', 'apiKey'], (result) => {
+    chrome.storage.local.get(['userProfile', 'apiKey', 'theme'], (result) => {
       if (result.userProfile) {
         userProfile = { ...defaultProfile, ...result.userProfile };
         updateProfileDisplay();
@@ -37,6 +42,9 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       if (result.apiKey) {
         apiKeyInput.value = result.apiKey;
+      }
+      if (result.theme) {
+        applyTheme(result.theme);
       }
     });
   }
@@ -79,6 +87,13 @@ document.addEventListener('DOMContentLoaded', () => {
     isSettingsVisible = true;
     mainView.classList.add('hidden');
     settingsView.classList.remove('hidden');
+  });
+
+  // Theme toggle
+  themeToggle.addEventListener('click', () => {
+    const newTheme = document.body.classList.contains('dark') ? 'light' : 'dark';
+    applyTheme(newTheme);
+    chrome.storage.local.set({ theme: newTheme });
   });
 
   // Back button
@@ -253,6 +268,9 @@ document.addEventListener('DOMContentLoaded', () => {
       userProfile = { ...defaultProfile, ...changes.userProfile.newValue };
       updateProfileDisplay();
       populateProfileInputs();
+    }
+    if (changes.theme) {
+      applyTheme(changes.theme.newValue);
     }
   });
 


### PR DESCRIPTION
## Summary
- support dark mode themes in popup and options pages
- remember theme preference
- update README with instructions for theme toggling

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_6873d907717c8320ba6694cb5ce69f41