### PR TITLE
Add UX improvements and keyboard shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ SmartFill AI is an intelligent Chrome extension that automates filling out web f
 - **User Profile Management**: Easily save and edit your profile information (name, email, professional summary, etc.) directly within the extension popup.
 - **Robust Field Detection**: Uses XPath to reliably identify form fields, making it compatible with dynamic pages built with frameworks like React or Angular.
 - **Secure**: Your API key and profile data are stored locally on your machine using Chrome's storage API and are never shared externally.
+- **Visual Preview & Undo**: Preview fields before filling and undo the last fill with a single click.
+- **Progress & Notifications**: See a spinner while filling and get success or error notifications.
+- **Keyboard Shortcut**: Press Ctrl+Shift+F to trigger SmartFill from any page.
 
 ## Quick Setup
 

--- a/background.js
+++ b/background.js
@@ -177,3 +177,11 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     return true; // Keep the message channel open for the async response
   }
 });
+
+chrome.commands.onCommand.addListener((command) => {
+  if (command === 'trigger-autofill') {
+    chrome.storage.local.set({ autoFillTrigger: true }, () => {
+      chrome.action.openPopup();
+    });
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,8 @@
     "storage",
     "scripting",
     "activeTab",
-    "webNavigation"
+    "webNavigation",
+    "notifications"
   ],
   "host_permissions": [
     "https://api.anthropic.com/",
@@ -30,5 +31,13 @@
       "run_at": "document_idle",
       "all_frames": true
     }
-  ]
+  ],
+  "commands": {
+    "trigger-autofill": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+F"
+      },
+      "description": "Trigger Smart Fill"
+    }
+  }
 }

--- a/popup.html
+++ b/popup.html
@@ -168,6 +168,43 @@
       font-style: italic;
       margin-top: 8px;
     }
+    .spinner {
+      border: 4px solid #f3f3f3;
+      border-top: 4px solid #667eea;
+      border-radius: 50%;
+      width: 24px;
+      height: 24px;
+      animation: spin 1s linear infinite;
+      margin: 10px auto;
+    }
+    @keyframes spin {
+      from { transform: rotate(0deg); }
+      to { transform: rotate(360deg); }
+    }
+    .preview-overlay {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0,0,0,0.5);
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      z-index: 1000;
+    }
+    .preview-modal {
+      background: #fff;
+      padding: 20px;
+      border-radius: 12px;
+      max-height: 80vh;
+      overflow-y: auto;
+      width: 90%;
+    }
+    .preview-list {
+      margin-top: 10px;
+      margin-bottom: 20px;
+    }
   </style>
 </head>
 <body>
@@ -187,7 +224,11 @@
         <button id="autofill-btn" class="autofill-btn">
           ✨ Smart Fill Form
         </button>
-        
+
+        <button id="undo-btn" class="btn btn-secondary hidden" style="width:100%; margin-bottom: 10px;">↩️ Undo Last Fill</button>
+
+        <div id="spinner" class="spinner hidden"></div>
+
         <div id="status" class="status">Ready to fill forms intelligently</div>
       </div>
     </div>
@@ -247,6 +288,15 @@
           </button>
         </div>
       </div>
+    </div>
+  </div>
+
+  <div id="preview-overlay" class="preview-overlay hidden">
+    <div class="preview-modal">
+      <h3>Preview Fields to Fill</h3>
+      <div id="preview-list" class="preview-list"></div>
+      <button id="confirm-fill-btn" class="btn" style="width:100%; margin-top:10px;">Fill Form</button>
+      <button id="cancel-preview-btn" class="btn btn-secondary" style="width:100%; margin-top:10px;">Cancel</button>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- enhance README with new UX features
- allow notification, command and undo features
- highlight preview fields and undo fills in `content.js`
- support hotkey and popup trigger in background script
- design preview, spinner and undo elements in popup UI
- implement preview workflow, undo, notifications and hotkey handling in `popup.js`

## Testing
- `node --check background.js`
- `node --check content.js`
- `node --check popup.js`
- `node --check options.js`

------
https://chatgpt.com/codex/tasks/task_e_6873de1c1e688320a4c1ce6bb00f727c